### PR TITLE
new interface for namespace promotion

### DIFF
--- a/examples/kuramoto_without_nd.jl
+++ b/examples/kuramoto_without_nd.jl
@@ -90,12 +90,12 @@ end
 
 #=
 We want the `connect_system` to get rid of the algebraic states for the edges. Therefore
-we have to provide an `outputs_map` which only contains the outputs of the vertices. By doing
+we have to provide a list of `outputs` which only contains the outputs of the vertices. By doing
 so the edge outputs will become `istates` of the `IOSystem` and upon connection might be reduced.
 =#
-out_map = [block.ϕ => block.ϕ for block in vert_blocks]
+outputs = [block.ϕ for block in vert_blocks]
 
-network = IOSystem(connections, vcat(vert_blocks, edge_blocks), outputs_map=out_map)
+network = IOSystem(connections, vcat(vert_blocks, edge_blocks), outputs=outputs)
 
 networkblock = connect_system(network, verbose=true)
 nothing #hide

--- a/src/IOSystems.jl
+++ b/src/IOSystems.jl
@@ -191,10 +191,10 @@ function IOSystem(cons,
                   autopromote = true
                   )
     namespaces = [sys.name for sys in io_systems]
-    @check allunique(namespaces) "Namespace collision in subsystems!"
+    allunique(namespaces) || throw(ArgumentError("Namespace collision in subsystems!"))
 
     ivs = unique([independent_variable(sys) for sys in io_systems])
-    @check length(ivs) == 1 "Multiple independent variables!"
+    length(ivs) == 1 || throw(ArgumentError("Multiple independent variables!"))
 
     @check allunique(first.(cons)) "Multiple connections to same input!"
     nspcd_inputs = vcat([namespace_inputs(sys) for sys in io_systems]...)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -12,7 +12,7 @@ macro check(cond::Expr, msg)
         end
     end
     print = :(@show($(repr(cond)),$(variables...)))
-    return :(if !$(esc(cond)); $print; throw(ArgumentError($msg)) end)
+    return :(if !$(esc(cond)); $print; throw(ArgumentError(esc($msg))) end)
 end
 
 """

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -12,7 +12,7 @@ macro check(cond::Expr, msg)
         end
     end
     print = :(@show($(repr(cond)),$(variables...)))
-    return :(if !$(esc(cond)); $print; throw(ArgumentError(esc($msg))) end)
+    return :(if !$(esc(cond)); $print; throw(ArgumentError($msg)) end)
 end
 
 """

--- a/test/IOSystems_test.jl
+++ b/test/IOSystems_test.jl
@@ -121,12 +121,13 @@ using LightGraphs
     @testset "iosystem asserts" begin
         @parameters t i(t)
         @variables o(t)
-        iob1 = IOBlock([o~i],[i],[o],name=:name)
-        iob2 = IOBlock([o~i],[i],[o],name=:name)
+        iob1 = IOBlock([o ~ i],[i],[o],name=:name)
+        iob2 = IOBlock([o ~ i],[i],[o],name=:name)
 
         # namespace collision
         @test_throws ArgumentError IOSystem([iob2.i=>iob1.o], [iob1, iob2])
-        iob2 = IOBlock([o~i],[i],[o])
+
+        iob2 = IOBlock([o ~ i],[i],[o])
         # mulitiple conneections to same input
         @test_throws ArgumentError IOSystem([iob1.i=>iob1.o, iob1.i=>iob2.o], [iob1, iob2])
         # make sure that alle of form input => output
@@ -137,7 +138,7 @@ using LightGraphs
         @test_throws ArgumentError IOSystem([iob2.i=>iob1.o], [iob1, iob2],
                                             namespace_map = [iob2.i => i])
         # assert that rhs of input map is unique
-        iob3 = IOBlock([o~i],[i],[o])
+        iob3 = IOBlock([o ~ i],[i],[o])
         @test_throws ArgumentError IOSystem([iob2.i=>iob1.o],
                                              [iob1, iob2, iob3],
                                              namespace_map = [iob1.i => i, iob3.i => i])

--- a/test/function_generation_test.jl
+++ b/test/function_generation_test.jl
@@ -11,12 +11,12 @@ using LinearAlgebra
         @parameters t a b
         @variables x(t) y(t)
         @derivatives D'~t
-        eqs = [D(x)~y,
+        eqs = [D(x) ~ y,
                y ~ x,
                2*b + 8 ~ a + a,
                1 ~ x + y]
         eqs = transform_algebraic_equations(eqs)
-        @test eqs == [D(x)~y,
+        @test eqs == [D(x) ~ y,
                       0 ~ x - y,
                       0 ~ (a + a) - (2*b + 8),
                       0 ~ (x + y) - 1]
@@ -27,7 +27,7 @@ using LinearAlgebra
         @parameters t
         @variables x(t) y(t) a(t) b(t)
         @derivatives D'~t
-        eqs = [D(x)~x, D(y)~y, 0 ~ x+y+a, 0 ~ x+y+b]
+        eqs = [D(x) ~ x, D(y) ~ y, 0 ~ x+y+a, 0 ~ x+y+b]
         @test reorder_by_states(eqs, [x,y,a,b]) == eqs[[1,2,3,4]]
         @test reorder_by_states(eqs, [y,x,a,b]) == eqs[[2,1,3,4]]
         @test reorder_by_states(eqs, [a,x,y,b]) == eqs[[3,1,2,4]]
@@ -62,10 +62,10 @@ using LinearAlgebra
         @parameters t
         @variables x(t) y(t) a(t) b(t)
         @derivatives D'~t
-        eqs = [D(x)~x, D(y)~y, 0 ~ x+y+a, 0 ~ x+y+b]
+        eqs = [D(x) ~ x, D(y) ~ y, 0 ~ x+y+a, 0 ~ x+y+b]
         @test generate_massmatrix(eqs) == Diagonal([1,1,0,0])
         @test generate_massmatrix(eqs[[1,3,2,4]]) == Diagonal([1,0,1,0])
-        eqs = [D(x)~x, D(y)~y]
+        eqs = [D(x) ~ x, D(y) ~ y]
         @test generate_massmatrix(eqs) == I
     end
 
@@ -89,7 +89,7 @@ using LinearAlgebra
         @parameters t a i(t)
         @variables x(t) y(t)
         @derivatives D'~t
-        iob = IOBlock([D(x)~a*i, D(y)~x], [i], [x, y])
+        iob = IOBlock([D(x) ~ a*i, D(y) ~ x], [i], [x, y])
 
         iof = generate_io_function(iob);
         @test iof.massm == I
@@ -116,7 +116,7 @@ using LinearAlgebra
         @parameters t a i1(t) i2(t)
         @variables x(t) y(t)
         @derivatives D'~t
-        iob = IOBlock([x~a*i1, y~i2], [i1, i2], [x, y])
+        iob = IOBlock([x ~ a*i1, y ~ i2], [i1, i2], [x, y])
 
         iof = generate_io_function(iob);
 
@@ -137,7 +137,7 @@ using LinearAlgebra
         @variables o1(t) o2(t)
         @derivatives D'~t
 
-        iob = IOBlock([D(o1)~a*i1 + b, D(o2)~o1+i2], [i1, i2], [o1, o2])
+        iob = IOBlock([D(o1) ~ a*i1 + b, D(o2) ~ o1+i2], [i1, i2], [o1, o2])
 
         allequal(v1, v2) = all([isequal(e1, e2) for (e1, e2) ∈ zip(v1, v2)])
 

--- a/test/transformations_test.jl
+++ b/test/transformations_test.jl
@@ -34,29 +34,29 @@ end
         eqs = [D(x) ~ x,
                D(y) ~ y,
                o ~ a^b]
-        reqs = remove_superfluous_states(eqs, [x])
+        reqs = remove_superfluous_states(eqs, t, [x])
         @test reqs == eqs[[1]]
-        reqs = remove_superfluous_states(eqs, [y])
+        reqs = remove_superfluous_states(eqs, t, [y])
         @test reqs == eqs[[2]]
-        reqs = remove_superfluous_states(eqs, [o])
+        reqs = remove_superfluous_states(eqs, t, [o])
         @test reqs == eqs[[3]]
         eqs = [D(x) ~ y,
                D(y) ~ x+o,
                o ~ a^b]
-        reqs = remove_superfluous_states(eqs, [y])
+        reqs = remove_superfluous_states(eqs, t, [y])
         @test reqs == eqs
-        reqs = remove_superfluous_states(eqs, [x])
+        reqs = remove_superfluous_states(eqs, t, [x])
         @test reqs == eqs
-        reqs = remove_superfluous_states(eqs, [o])
+        reqs = remove_superfluous_states(eqs, t, [o])
         @test reqs == eqs[[3]]
         eqs = [D(x) ~ x+o,
                D(y) ~ y,
                o ~ a^b]
-        reqs = remove_superfluous_states(eqs, [x])
+        reqs = remove_superfluous_states(eqs, t, [x])
         @test reqs == eqs[[1,3]]
-        reqs = remove_superfluous_states(eqs, [y])
+        reqs = remove_superfluous_states(eqs, t, [y])
         @test reqs == eqs[[2]]
-        reqs = remove_superfluous_states(eqs, [o])
+        reqs = remove_superfluous_states(eqs, t, [o])
         @test reqs == eqs[[3]]
     end
 
@@ -144,20 +144,21 @@ end
         @parameters t i1(t) i2(t) a b ina(t) inb(t)
         @variables x1(t) x2(t) o(t) add(t)
         @derivatives D'~t
-        eqs1  = [D(x1)~a*i1, D(x2)~i2, o~x1+x2]
+        eqs1  = [D(x1) ~ a*i1, D(x2)~i2, o~x1+x2]
         iob1 = IOBlock(eqs1, [i1, i2], [o], name=:A)
-        eqs2  = [D(x1)~b*i1, D(x2)~i2, o~x1+x2]
+        eqs2  = [D(x1) ~ b*i1, D(x2)~i2, o~x1+x2]
         iob2 = IOBlock(eqs2, [i1, i2], [o], name=:B)
         ioadd = IOBlock([add ~ ina + inb], [ina, inb], [add], name=:add)
         @parameters in1(t) in2(t) in3(t) in4(t)
         @variables out(t)
         sys = IOSystem([ioadd.ina => iob1.o, ioadd.inb => iob2.o],
                        [iob1, iob2, ioadd],
-                       inputs_map = Dict(iob1.i1 => in1,
-                                         iob1.i2 => in2,
-                                         iob2.i1 => in3,
-                                         iob2.i2 => in4),
-                       outputs_map = Dict(ioadd.add => out),
+                       namespace_map = Dict(iob1.i1 => in1,
+                                            iob1.i2 => in2,
+                                            iob2.i1 => in3,
+                                            iob2.i2 => in4,
+                                            ioadd.add => out),
+                       outputs = [out],
                        name=:sys)
         iob = connect_system(sys)
 
@@ -200,7 +201,8 @@ end
         b1 = IOBlock([D(x) ~ i], [i], [x], name=:a)
         b2 = IOBlock([o ~ i], [i], [o], name=:b)
         subsys = IOSystem([b1.i=>b2.o, b2.i=>b1.x], [b1, b2], name=:A,
-                          outputs_map = [b1.x=>x])
+                          namespace_map = [b1.x=>x],
+                          outputs = [x])
         @test Set(subsys.removed_states) == Set()
 
         subsysA = connect_system(subsys)


### PR DESCRIPTION
changes the `IOSystem` constructor
- single `namespace_map` instead of maps for `inputs`, `istates`, `iparams` and `outputs`
- the new `outputs` argument specifies the outputs of the subsystems which should become outputs of connected system